### PR TITLE
Add Device::context().

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -95,6 +95,11 @@ impl Device {
         Device(ctxt, cb)
     }
 
+    /// Return the underlying context for the device
+    pub fn context(&self) -> &__gl::Gl {
+        &self.0
+    }
+
     pub unsafe fn limits(&self) -> DeviceLimits {
         DeviceLimits {
             max_compute_work_group_invocations: self


### PR DESCRIPTION
Exposes the context loaded by the device so the user can make raw GL calls.

Perhaps there's already a method of accomplishing this, but I couldn't find it.