### PR TITLE
explicit log retrieval for shader and pipeline creation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use crate::__gl;
 
 use crate::device::Device;
-use crate::pipeline::Shader;
+use crate::pipeline::{Pipeline, Shader};
 use std::{error, fmt, result};
 
 /// Error return codes
@@ -19,7 +19,10 @@ pub enum Error {
     OutOfMemory,
 
     /// Shader compilation failure.
-    CompileError(Option<Shader>),
+    CompileError(Shader),
+
+    /// Link pipeline failure.
+    LinkError(Pipeline),
 }
 
 /// A specialized Result type for `grr` operations.
@@ -41,7 +44,8 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match *self {
             Error::OutOfMemory => write!(fmt, "OutOfMemory"),
-            Error::CompileError(_) => write!(fmt, "CompileError")
+            Error::CompileError(_) => write!(fmt, "CompileError"),
+            Error::LinkError(_) => write!(fmt, "LinkError"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
 use crate::__gl;
 
 use crate::device::Device;
+use crate::pipeline::Shader;
 use std::{error, fmt, result};
 
 /// Error return codes
@@ -16,6 +17,9 @@ use std::{error, fmt, result};
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     OutOfMemory,
+
+    /// Shader compilation failure.
+    CompileError(Option<Shader>),
 }
 
 /// A specialized Result type for `grr` operations.
@@ -37,6 +41,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match *self {
             Error::OutOfMemory => write!(fmt, "OutOfMemory"),
+            Error::CompileError(_) => write!(fmt, "CompileError")
         }
     }
 }


### PR DESCRIPTION
The idea behind this PR is to provide some interface to retrieve the compilation and link logs from shaders and programs/pipelines, respectively, so that the client program can do something else with them. I also wanted to provide functions that don't print to stdout. 

I guess ideally I would actually replace the existing functions with ones that don't print anything, or make it optional, but I didn't want to the change the interface or the expectations of the current functions

I'm not especially attached to the names of some of the functions, so i'm open to suggestions there. `create_pipeline` is inconsistent with the other specific pipelines, for instance, because it doesn't print the link errors. 