### PR TITLE
copy_image_to_* implementations

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -528,8 +528,7 @@ impl Device {
         offset: Offset,
         extent: Extent,
         layout: SubresourceLayout,
-        buf_size: i32,
-        buf_ptr: *mut __gl::types::GLvoid,
+        (buf_size, buf_ptr): (i32, *mut __gl::types::GLvoid),
     ) {
         use __gl::types::{GLint, GLsizei};
         self.set_pixel_pack_params(&layout);
@@ -591,8 +590,10 @@ impl Device {
             offset,
             extent,
             layout,
-            (data.len() * std::mem::size_of::<T>()) as _,
-            data.as_mut_ptr() as _,
+            (
+                (data.len() * std::mem::size_of::<T>()) as _,
+                data.as_mut_ptr() as _,
+            ),
         );
     }
 
@@ -613,8 +614,7 @@ impl Device {
             offset,
             extent,
             layout,
-            buffer.size as _,
-            buffer.offset as _,
+            (buffer.size as _, buffer.offset as _),
         );
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -396,7 +396,7 @@ impl Device {
     }
 
     /// Copy image data from buffer to device memory.
-    pub unsafe fn copy_buffer_to_image<T>(
+    pub unsafe fn copy_buffer_to_image(
         &self,
         image: Image,
         subresource: SubresourceLevel,

--- a/src/image.rs
+++ b/src/image.rs
@@ -186,35 +186,6 @@ pub enum ImageViewType {
     CubeArray,
 }
 
-/// Represent either an Image or and ImageView.
-#[derive(Copy, Clone)]
-pub enum ImageOrView {
-    Image(Image),
-    View(ImageView),
-}
-
-impl From<Image> for ImageOrView {
-    fn from(img: Image) -> Self {
-        ImageOrView::Image(img)
-    }
-}
-
-impl From<ImageView> for ImageOrView {
-    fn from(img_view: ImageView) -> Self {
-        ImageOrView::View(img_view)
-    }
-}
-
-impl Object for ImageOrView {
-    const TYPE: ObjectType = ObjectType::Image;
-    fn handle(&self) -> GLuint {
-        match self {
-            Self::Image(img) => img.handle(),
-            Self::View(view) => view.handle(),
-        }
-    }
-}
-
 /// Subresource of an image.
 pub struct SubresourceRange {
     /// Range of mip levels.

--- a/src/image.rs
+++ b/src/image.rs
@@ -120,6 +120,15 @@ impl ImageType {
         }
     }
 
+    /// Full extent of the image dimensions for a single layer.
+    pub fn full_extent(&self) -> Extent {
+        Extent {
+            width: self.width(),
+            height: self.height(),
+            depth: self.depth(),
+        }
+    }
+
     /// Return the number of samples in a texel of the image.
     pub fn samples(&self) -> u32 {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,12 +99,16 @@ pub struct Region {
     pub h: i32,
 }
 
-///
+/// Starting location for copying from or to texture data.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Offset {
     pub x: i32,
     pub y: i32,
     pub z: i32,
+}
+
+impl Offset {
+    pub const ORIGIN: Offset = Offset { x: 0, y: 0, z: 0 };
 }
 
 ///


### PR DESCRIPTION
Implement `copy_image_to_buffer` and `copy_image_to_host` for retrieving texture data.

The routines take a `u32` level, rather than a `SubresourceLevel`, because the underlying `GetTextureImage` call always reads in all of the layers. This also why I have the function take a type that converts to `ImageOrView`, rather than an `Image` view directly. One could also have separate functions for `Image`s and `ImageView`s, but this solution seems the most ergonomic.

This branch also contains a minor bugfix, to remove the unnecessary generic parameter from `Device::copy_buffer_to_image`.